### PR TITLE
feat(sprint-4): dashboard de humor com Chart.js e campo humor nas ses…

### DIFF
--- a/nodus-app/.claude/settings.local.json
+++ b/nodus-app/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\Davi\\\\Códigos\\\\NODUS\\\\NODUS-Projeto-Integrador-II\\\\nodus-app\\\\src\\\\app\" -Recurse -File)",
+      "Bash(Select-Object -ExpandProperty FullName)",
+      "Bash(Sort-Object)"
+    ]
+  }
+}

--- a/nodus-app/backend/src/database/db.ts
+++ b/nodus-app/backend/src/database/db.ts
@@ -17,3 +17,8 @@ pool.query(`
     ALTER TABLE sessao
     ADD COLUMN IF NOT EXISTS horario VARCHAR(10);
 `).catch(err => console.error('[db] Erro ao aplicar migration de horario:', err));
+
+pool.query(`
+    ALTER TABLE sessao
+    ADD COLUMN IF NOT EXISTS humor INTEGER;
+`).catch(err => console.error('[db] Erro ao aplicar migration de humor:', err));

--- a/nodus-app/backend/src/modules/sessao/sessao.model.ts
+++ b/nodus-app/backend/src/modules/sessao/sessao.model.ts
@@ -3,6 +3,7 @@ export interface Sessao {
   data: string;
   horario: string;
   observacoes?: string;
+  humor?: number;
   id_paciente: number;
   id_psicologo: number;
 }
@@ -11,6 +12,7 @@ export interface CriarSessaoDto {
   data: string;
   horario: string;
   observacoes?: string;
+  humor?: number;
   id_paciente: number;
   id_psicologo: number;
 }

--- a/nodus-app/backend/src/modules/sessao/sessao.repository.ts
+++ b/nodus-app/backend/src/modules/sessao/sessao.repository.ts
@@ -1,18 +1,16 @@
 import { pool } from '../../database/db';
 import { Sessao } from './sessao.model';
 
+const COLUNAS = `id_sessao, data, horario, observacoes, humor, id_paciente, id_psicologo`;
+
 export const findAll = async (): Promise<Sessao[]> => {
-  const result = await pool.query(
-    `SELECT id_sessao, data, horario, observacoes, id_paciente, id_psicologo
-     FROM sessao`
-  );
+  const result = await pool.query(`SELECT ${COLUNAS} FROM sessao`);
   return result.rows;
 };
 
 export const findById = async (id: number): Promise<Sessao | null> => {
   const result = await pool.query(
-    `SELECT id_sessao, data, horario, observacoes, id_paciente, id_psicologo
-     FROM sessao WHERE id_sessao = $1`,
+    `SELECT ${COLUNAS} FROM sessao WHERE id_sessao = $1`,
     [id]
   );
   return result.rows[0] ?? null;
@@ -20,9 +18,7 @@ export const findById = async (id: number): Promise<Sessao | null> => {
 
 export const findByPaciente = async (id_paciente: number): Promise<Sessao[]> => {
   const result = await pool.query(
-    `SELECT id_sessao, data, horario, observacoes, id_paciente, id_psicologo
-     FROM sessao WHERE id_paciente = $1
-     ORDER BY data DESC, horario DESC`,
+    `SELECT ${COLUNAS} FROM sessao WHERE id_paciente = $1 ORDER BY data DESC, horario DESC`,
     [id_paciente]
   );
   return result.rows;
@@ -30,9 +26,7 @@ export const findByPaciente = async (id_paciente: number): Promise<Sessao[]> => 
 
 export const findByPsicologo = async (id_psicologo: number): Promise<Sessao[]> => {
   const result = await pool.query(
-    `SELECT id_sessao, data, horario, observacoes, id_paciente, id_psicologo
-     FROM sessao WHERE id_psicologo = $1
-     ORDER BY data DESC, horario DESC`,
+    `SELECT ${COLUNAS} FROM sessao WHERE id_psicologo = $1 ORDER BY data DESC, horario DESC`,
     [id_psicologo]
   );
   return result.rows;
@@ -40,10 +34,10 @@ export const findByPsicologo = async (id_psicologo: number): Promise<Sessao[]> =
 
 export const create = async (data: Sessao): Promise<Sessao> => {
   const result = await pool.query(
-    `INSERT INTO sessao (data, horario, observacoes, id_paciente, id_psicologo)
-     VALUES ($1, $2, $3, $4, $5)
-     RETURNING id_sessao, data, horario, observacoes, id_paciente, id_psicologo`,
-    [data.data, data.horario, data.observacoes, data.id_paciente, data.id_psicologo]
+    `INSERT INTO sessao (data, horario, observacoes, humor, id_paciente, id_psicologo)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING ${COLUNAS}`,
+    [data.data, data.horario, data.observacoes ?? null, data.humor ?? null, data.id_paciente, data.id_psicologo]
   );
   return result.rows[0];
 };
@@ -51,21 +45,19 @@ export const create = async (data: Sessao): Promise<Sessao> => {
 export const update = async (id: number, data: Partial<Sessao>): Promise<Sessao | null> => {
   const result = await pool.query(
     `UPDATE sessao
-     SET data = COALESCE($1, data),
-         horario = COALESCE($2, horario),
-         observacoes = COALESCE($3, observacoes)
-     WHERE id_sessao = $4
-     RETURNING id_sessao, data, horario, observacoes, id_paciente, id_psicologo`,
-    [data.data, data.horario, data.observacoes, id]
+     SET data        = COALESCE($1, data),
+         horario     = COALESCE($2, horario),
+         observacoes = COALESCE($3, observacoes),
+         humor       = COALESCE($4, humor)
+     WHERE id_sessao = $5
+     RETURNING ${COLUNAS}`,
+    [data.data, data.horario, data.observacoes, data.humor, id]
   );
   return result.rows[0] ?? null;
 };
 
 export const remove = async (id: number): Promise<boolean> => {
-  const result = await pool.query(
-    'DELETE FROM sessao WHERE id_sessao = $1',
-    [id]
-  );
+  const result = await pool.query('DELETE FROM sessao WHERE id_sessao = $1', [id]);
   return (result.rowCount ?? 0) > 0;
 };
 

--- a/nodus-app/package-lock.json
+++ b/nodus-app/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/material": "^21.2.9",
         "@angular/platform-browser": "^21.2.0",
         "@angular/router": "^21.2.0",
+        "chart.js": "^4.5.1",
         "crypto-js": "^4.2.0",
         "dexie": "^4.3.0",
         "rxjs": "~7.8.0",
@@ -2194,6 +2195,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
       "version": "3.0.5",
@@ -4657,6 +4664,18 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "5.0.0",

--- a/nodus-app/package.json
+++ b/nodus-app/package.json
@@ -19,6 +19,7 @@
     "@angular/material": "^21.2.9",
     "@angular/platform-browser": "^21.2.0",
     "@angular/router": "^21.2.0",
+    "chart.js": "^4.5.1",
     "crypto-js": "^4.2.0",
     "dexie": "^4.3.0",
     "rxjs": "~7.8.0",

--- a/nodus-app/src/app/components/add-section-paciente/add-section-paciente.html
+++ b/nodus-app/src/app/components/add-section-paciente/add-section-paciente.html
@@ -111,6 +111,17 @@
                 </div>
             </div>
             <div class="input-container">
+                <label>Humor do paciente:</label>
+                <select class="input" formControlName="humor">
+                    <option [ngValue]="null">- Não registrado -</option>
+                    <option [ngValue]="1">😢 Muito Mal</option>
+                    <option [ngValue]="2">😟 Mal</option>
+                    <option [ngValue]="3">😐 Neutro</option>
+                    <option [ngValue]="4">😊 Bem</option>
+                    <option [ngValue]="5">😆 Muito Bem</option>
+                </select>
+            </div>
+            <div class="input-container">
                 <label>Observações:</label>
                 <input class="input" type="text" formControlName="observacoes"
                     placeholder="Temas, evolução, exercícios propostos...">

--- a/nodus-app/src/app/components/add-section-paciente/add-section-paciente.ts
+++ b/nodus-app/src/app/components/add-section-paciente/add-section-paciente.ts
@@ -48,6 +48,7 @@ export class AddSectionPaciente implements OnInit {
     data: ['', Validators.required],
     horario: ['', Validators.required],
     observacoes: [''],
+    humor: [null as number | null],
   });
 
   ngOnInit(): void {
@@ -91,13 +92,14 @@ export class AddSectionPaciente implements OnInit {
     this.loading.set(true);
     this.erro.set(null);
 
-    const { id_paciente, data, horario, observacoes } = this.sessaoForm.value;
+    const { id_paciente, data, horario, observacoes, humor } = this.sessaoForm.value;
 
     this.sessaoService.create({
       id_paciente: id_paciente!,
       data: data!,
       horario: horario!,
       observacoes: observacoes ?? undefined,
+      humor: humor ?? undefined,
       id_psicologo: psi.id_psicologo,
     }).subscribe({
       next: () => this.dialogRef.close(true),

--- a/nodus-app/src/app/core/database/db.ts
+++ b/nodus-app/src/app/core/database/db.ts
@@ -16,6 +16,7 @@ export interface SessaoLocal {
   data: string;
   horario: string;
   observacoes?: string; // sempre armazenado criptografado
+  humor?: number;
   id_paciente: number;
   id_psicologo: number;
 }

--- a/nodus-app/src/app/core/services/sessao.model.ts
+++ b/nodus-app/src/app/core/services/sessao.model.ts
@@ -3,6 +3,7 @@ export interface Sessao {
   data: string;
   horario: string;
   observacoes?: string;
+  humor?: number;
   id_paciente: number;
   id_psicologo: number;
 }
@@ -11,6 +12,7 @@ export interface CriarSessaoDto {
   data: string;
   horario: string;
   observacoes?: string;
+  humor?: number;
   id_paciente: number;
   id_psicologo: number;
 }

--- a/nodus-app/src/app/pages/home-page/home-page.html
+++ b/nodus-app/src/app/pages/home-page/home-page.html
@@ -43,6 +43,18 @@
         </div>
     </section>
 
+    <section class="chart-section">
+        <div class="next-header">
+            <span>Evolução do Humor</span>
+        </div>
+        <div class="chart-wrapper">
+            @if (!temDadosHumor()) {
+                <p class="chart-empty">Registre o humor nas sessões para ver a evolução</p>
+            }
+            <canvas #canvasHumor [hidden]="!temDadosHumor()"></canvas>
+        </div>
+    </section>
+
     <section class="next-section">
         <div class="next-header">
             <span>Próximas sessões</span>

--- a/nodus-app/src/app/pages/home-page/home-page.scss
+++ b/nodus-app/src/app/pages/home-page/home-page.scss
@@ -201,6 +201,37 @@
 
     }
 
+    .chart-section {
+        display: flex;
+        flex-direction: column;
+        max-width: 480px;
+        width: 100%;
+        gap: 10px;
+
+        .chart-wrapper {
+            background-color: white;
+            border-radius: 15px;
+            padding: 16px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+            height: 200px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
+            canvas {
+                width: 100% !important;
+                height: 100% !important;
+            }
+
+            .chart-empty {
+                font-size: 13px;
+                color: #a08e87;
+                text-align: center;
+                margin: 0;
+            }
+        }
+    }
+
     .overlay {
         position: fixed;
         inset: 0;

--- a/nodus-app/src/app/pages/home-page/home-page.ts
+++ b/nodus-app/src/app/pages/home-page/home-page.ts
@@ -1,11 +1,16 @@
 import { DatePipe } from '@angular/common';
-import { Component, computed, inject, OnInit } from '@angular/core';
+import { AfterViewInit, Component, computed, effect, ElementRef, inject, OnDestroy, OnInit, signal, ViewChild } from '@angular/core';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { Router } from '@angular/router';
+import { Chart, registerables } from 'chart.js';
 import { AddSectionPaciente } from '../../components/add-section-paciente/add-section-paciente';
 import { AuthService } from '../../core/auth/auth.service';
 import { PacienteService } from '../../core/services/paciente.service';
 import { SessaoService } from '../../core/services/sessao.service';
+
+Chart.register(...registerables);
+
+const HUMOR_EMOJI: Record<number, string> = { 1: '😢', 2: '😟', 3: '😐', 4: '😊', 5: '😆' };
 
 @Component({
   selector: 'app-home-page',
@@ -13,12 +18,15 @@ import { SessaoService } from '../../core/services/sessao.service';
   templateUrl: './home-page.html',
   styleUrl: './home-page.scss',
 })
-export class HomePage implements OnInit {
+export class HomePage implements OnInit, AfterViewInit, OnDestroy {
   private authService = inject(AuthService);
   private pacienteService = inject(PacienteService);
   private sessaoService = inject(SessaoService);
   private dialog = inject(MatDialog);
   private router = inject(Router);
+
+  @ViewChild('canvasHumor') canvasRef!: ElementRef<HTMLCanvasElement>;
+  private grafico?: Chart;
 
   readonly psiNome = computed(() => this.authService.psicologoAtual()?.nome ?? '');
 
@@ -55,11 +63,90 @@ export class HomePage implements OnInit {
       }));
   });
 
+  // Últimas 15 sessões com humor registrado, ordenadas do mais antigo ao mais recente
+  readonly dadosGrafico = computed(() => {
+    const sessoes = this.sessaoService.sessoes()
+      .filter(s => s.humor != null)
+      .sort((a, b) => new Date(a.data).getTime() - new Date(b.data).getTime())
+      .slice(-15);
+
+    return {
+      labels: sessoes.map(s => {
+        const d = new Date(s.data);
+        return `${String(d.getDate()).padStart(2, '0')}/${String(d.getMonth() + 1).padStart(2, '0')}`;
+      }),
+      valores: sessoes.map(s => s.humor!),
+    };
+  });
+
+  readonly temDadosHumor = computed(() => this.dadosGrafico().valores.length > 0);
+
+  constructor() {
+    // Atualiza o gráfico reativamente sempre que os dados mudarem
+    effect(() => {
+      const dados = this.dadosGrafico();
+      if (!this.grafico) return;
+      this.grafico.data.labels = dados.labels;
+      this.grafico.data.datasets[0].data = dados.valores;
+      this.grafico.update('none');
+    });
+  }
+
   ngOnInit(): void {
     const psi = this.authService.psicologoAtual();
     if (!psi) return;
     this.pacienteService.getByPsicologo(psi.id_psicologo).subscribe();
     this.sessaoService.getByPsicologo(psi.id_psicologo).subscribe();
+  }
+
+  ngAfterViewInit(): void {
+    const dados = this.dadosGrafico();
+    this.grafico = new Chart(this.canvasRef.nativeElement, {
+      type: 'line',
+      data: {
+        labels: dados.labels,
+        datasets: [{
+          data: dados.valores,
+          borderColor: '#c3334b',
+          backgroundColor: 'rgba(195, 51, 75, 0.08)',
+          tension: 0.4,
+          fill: true,
+          pointBackgroundColor: '#c3334b',
+          pointRadius: 5,
+          pointHoverRadius: 7,
+        }],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label: ctx => HUMOR_EMOJI[ctx.parsed.y as number] ?? String(ctx.parsed.y),
+            },
+          },
+        },
+        scales: {
+          y: {
+            min: 1,
+            max: 5,
+            ticks: {
+              stepSize: 1,
+              callback: val => HUMOR_EMOJI[val as number] ?? '',
+            },
+            grid: { color: 'rgba(0,0,0,0.05)' },
+          },
+          x: {
+            grid: { display: false },
+          },
+        },
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.grafico?.destroy();
   }
 
   goToSections(): void {


### PR DESCRIPTION
…sões

- sessao.model.ts (front+back): adicionado humor?: number em Sessao e CriarSessaoDto
- db.ts (backend): migration automática ADD COLUMN IF NOT EXISTS humor INTEGER
- sessao.repository.ts: constante COLUNAS inclui humor; INSERT e UPDATE passam humor como $4/$5
- db.ts (frontend): SessaoLocal recebe humor?: number para cache offline
- add-section-paciente: sessaoForm inclui campo humor; salvarSessao() envia humor; select com emojis 😢→😆 no formulário
- home-page.ts: dadosGrafico computed() filtra sessões com humor, ordena por data e fatia as últimas 15; effect() atualiza o Chart.js reativamente sem re-renderizar o componente; ngAfterViewInit inicializa o gráfico de linha; ngOnDestroy destrói instância para evitar leak
- home-page.html: seção .chart-section com canvas; estado vazio enquanto não há dados
- home-page.scss: estilos do card do gráfico (200px, branco, sombra suave)

Falta para front:
-Página Agenda
-Página Info-paciente(futura issue)
-Ajuste css
-Limpeza de pastas e arquivos